### PR TITLE
server.js updates comments variable after get request to "comments.json"

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ app.use(bodyParser.urlencoded({extended: true}));
 app.get('/comments.json', function(req, res) {
   res.setHeader('Content-Type', 'application/json');
   res.send(JSON.stringify(comments));
+  comments = JSON.parse(fs.readFileSync('_comments.json'));
 });
 
 app.post('/comments.json', function(req, res) {

--- a/server.js
+++ b/server.js
@@ -16,23 +16,26 @@ var express = require('express');
 var bodyParser = require('body-parser');
 var app = express();
 
-var comments = JSON.parse(fs.readFileSync('_comments.json'));
-
 app.use('/', express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
 
 app.get('/comments.json', function(req, res) {
-  comments = JSON.parse(fs.readFileSync('_comments.json'));
-  res.setHeader('Content-Type', 'application/json');
-  res.send(JSON.stringify(comments));
+  fs.readFile('_comments.json', function(err, data) {
+    res.setHeader('Content-Type', 'application/json');
+    res.send(data);
+  });
 });
 
 app.post('/comments.json', function(req, res) {
-  comments.push(req.body);
-  fs.writeFile('_comments.json', JSON.stringify(comments));
-  res.setHeader('Content-Type', 'application/json');
-  res.send(JSON.stringify(comments));
+  fs.readFile('_comments.json', function(err, data) {
+    var tempComments = JSON.parse(data);
+    tempComments.push(req.body);
+    fs.writeFile('_comments.json', JSON.stringify(tempComments), function(err) {
+      res.setHeader('Content-Type', 'application/json');
+      res.send(JSON.stringify(tempComments));
+    });
+  });
 });
 
 app.listen(3000);

--- a/server.js
+++ b/server.js
@@ -23,14 +23,14 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
 
 app.get('/comments.json', function(req, res) {
+  comments = JSON.parse(fs.readFileSync('_comments.json'));
   res.setHeader('Content-Type', 'application/json');
   res.send(JSON.stringify(comments));
-  comments = JSON.parse(fs.readFileSync('_comments.json'));
 });
 
 app.post('/comments.json', function(req, res) {
   comments.push(req.body);
-  fs.writeFile('_comments.json', JSON.stringify(comments))
+  fs.writeFile('_comments.json', JSON.stringify(comments));
   res.setHeader('Content-Type', 'application/json');
   res.send(JSON.stringify(comments));
 });


### PR DESCRIPTION
In the fetching data from the server section of the tutorial documentation, a method to poll the server is added so that the app polls the server every 2 seconds for changes to the server's _comments.json data (which will then reflected through dynamic updates to the DOM). Section of tutorial below:

![screen shot 2015-01-22 at 11 15 11 am](https://cloud.githubusercontent.com/assets/7741426/5862567/cf4cf890-a227-11e4-8e71-d24ae9f3dfce.png)

Here, in the tutorial, after adding the server polling it encourages you to change the _comments.json file so that you can see the app dynamically change when new information is obtained from the server.

The server file is setup to just fetch json data from a static file (_comments.json) by reading the file and then storing the contents of the file in a variable 'comments'. Then on a get requests to comments.json, the server sends the stringified comments data as a response. The problem is that the _comments.json file is currently only read one time by the server and never reread, so changes to the _comments.json file never change the comments variable. 

This push request updates the server.js file so that the server will re-read the _comments.json file and update the comments variable after every get request to comments.json. 