### PR TITLE
Move _comments.json read into proc

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -11,14 +11,14 @@
 require 'webrick'
 require 'json'
 
-comments = react_version = JSON.parse(File.read('./_comments.json'))
-
 puts 'Server started: http://localhost:3000/'
 
 root = File.expand_path './public'
 server = WEBrick::HTTPServer.new :Port => 3000, :DocumentRoot => root
 
 server.mount_proc '/comments.json' do |req, res|
+  comments = react_version = JSON.parse(File.read('./_comments.json'))
+
   if req.request_method == 'POST'
     # Assume it's well formed
     comments << req.query


### PR DESCRIPTION
If this file is read outside the proc, the server will never see updates to the json file and the response will always be the same. This allows manual editing/saving of the _comments.json file to be reflected in subsequent requests.