### PR TITLE
Update Go server

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,8 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.{js,rb}]
-indent_size=2
+indent_size = 2
+
+[*.go]
+indent_size = 8
+indent_style = tab

--- a/server.go
+++ b/server.go
@@ -64,12 +64,17 @@ func handleComments(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Write out the json response
-		commentsEncoder := json.NewEncoder(cFile)
-		commentsEncoder.Encode(comments)
+		// Pretty print the JSON, write to file
+		var encodedComments, _ = json.MarshalIndent(comments, "", "    ")
+		cFile.WriteAt(encodedComments, 0)
+
+		// send the encoded comments to the response
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(encodedComments)
 
 	case "GET":
 		// stream the contents of the file to the response
+		w.Header().Set("Content-Type", "application/json")
 		io.Copy(w, cFile)
 
 	default:
@@ -81,5 +86,6 @@ func handleComments(w http.ResponseWriter, r *http.Request) {
 func main() {
 	http.HandleFunc("/comments.json", handleComments)
 	http.Handle("/", http.FileServer(http.Dir("./public")))
+	log.Println("Server started: http://localhost:3000")
 	log.Fatal(http.ListenAndServe(":3000", nil))
 }


### PR DESCRIPTION
Follow up to #29. cc @freeformz 

This does a couple things, mostly to bring the Go server in line with our other servers.

- Log to stdout when starting the server
- Set response content type headers for JSON
- Pretty print the JSON when writing to disk
- Send the JSON as a response to POST requests

This is the first Go I've ever written so any feedback is welcome.