### PR TITLE
Correct editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{js,rb}]
+[*.{js,rb,css,html}]
 indent_size = 2
 
 [*.go]


### PR DESCRIPTION
The [HTML](https://github.com/reactjs/react-tutorial/blob/master/public/index.html) and [CSS](https://github.com/reactjs/react-tutorial/blob/master/public/css/base.css) is currently written using 2 spaces indentation. The editorconfig didn't reflect that.