### PR TITLE
Remove deprecated method

### DIFF
--- a/public/scripts/example.js
+++ b/public/scripts/example.js
@@ -101,14 +101,14 @@ var CommentList = React.createClass({
 var CommentForm = React.createClass({
   handleSubmit: function(e) {
     e.preventDefault();
-    var author = this.refs.author.getDOMNode().value.trim();
-    var text = this.refs.text.getDOMNode().value.trim();
+    var author = React.findDOMNode(this.refs.author).value.trim();
+    var text = React.findDOMNode(this.refs.text).value.trim();
     if (!text || !author) {
       return;
     }
     this.props.onCommentSubmit({author: author, text: text});
-    this.refs.author.getDOMNode().value = '';
-    this.refs.text.getDOMNode().value = '';
+    React.findDOMNode(this.refs.author).value = '';
+    React.findDOMNode(this.refs.text).value = '';
   },
   render: function() {
     return (


### PR DESCRIPTION
According to the official [API](http://facebook.github.io/react/docs/component-api.html#getdomnode), ```getDOMNode``` has been replaced with ```React.findDOMNode()```