### PR TITLE
fix failing to write utf-8 encoded characters into comments.json with ruby server

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -23,7 +23,11 @@ server.mount_proc '/comments.json' do |req, res|
 
   if req.request_method == 'POST'
     # Assume it's well formed
-    comments << req.query
+    comment = {}
+    req.query.each do |key, value|
+      comment[key] = value.force_encoding('UTF-8')
+    end
+    comments << comment
     File.write('./comments.json', JSON.pretty_generate(comments, :indent => '    '))
   end
 


### PR DESCRIPTION
When trying the example with Chinese characters, the ruby server will fail with errors:

![screen shot 2015-05-16 at 23 30 55](https://cloud.githubusercontent.com/assets/1091472/7666819/d9cff040-fc24-11e4-8740-2617535bb1d3.png)

Because `req.query` in WEBrick would transform something like `%E9%99%88%E4%B8%89` into `\xE9\x99\x88\xE4\xB8\x89`, then it messes the characters. So this commit is kinda a workaround.
