### PR TITLE
Ensure we are using utf-8 for file IO

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -13,6 +13,9 @@ require 'json'
 
 port = ENV['PORT'].nil? ? 3000 : ENV['PORT'].to_i
 
+# Ensure the file IO uses UTF-8 by default
+Encoding::default_external = Encoding::default_internal = Encoding::UTF_8
+
 puts "Server started: http://localhost:#{port}/"
 
 root = File.expand_path './public'


### PR DESCRIPTION
Without this on a system that does not have utf-8 as the default (e.g. the latest https://hub.docker.com/_/ruby/), the user will hit an error as soon as JSON.parse() gets to the apostrophe in the example.json.

`ERROR Encoding::InvalidByteSequenceError: "\xE2" on US-ASCII`

This fix makes sure that when we do File.read() it is going to return utf-8 by default, which is what the script was originally expecting.