### PR TITLE
JS: Fix undefined file reference when invoked from another directory 

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,6 +16,8 @@ var express = require('express');
 var bodyParser = require('body-parser');
 var app = express();
 
+var COMMENTS_FILE = path.join(__dirname, 'comments.json');
+
 app.set('port', (process.env.PORT || 3000));
 
 app.use('/', express.static(path.join(__dirname, 'public')));
@@ -23,17 +25,17 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
 
 app.get('/api/comments', function(req, res) {
-  fs.readFile('comments.json', function(err, data) {
+  fs.readFile(COMMENTS_FILE, function(err, data) {
     res.setHeader('Cache-Control', 'no-cache');
     res.json(JSON.parse(data));
   });
 });
 
 app.post('/api/comments', function(req, res) {
-  fs.readFile('comments.json', function(err, data) {
+  fs.readFile(COMMENTS_FILE, function(err, data) {
     var comments = JSON.parse(data);
     comments.push(req.body);
-    fs.writeFile('comments.json', JSON.stringify(comments, null, 4), function(err) {
+    fs.writeFile(COMMENTS_FILE, JSON.stringify(comments, null, 4), function(err) {
       res.setHeader('Cache-Control', 'no-cache');
       res.json(comments);
     });


### PR DESCRIPTION
Fixes an undefined-file error when attempting to access the API when JavaScript server is started from a directory other than the project root directory, e.g.,

```
$ PORT=3001 node node_modules/react-tutorial/server.js

Server started: http://localhost:3001/
undefined:1
undefined
^

SyntaxError: Unexpected token u
    at Object.parse (native)
    at ReadFileContext.callback (/Users/rob/code/react-tutorial-official/server.js:28:19)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:303:13)
```

This change makes the `comments.json` file reference relative to the `server.js` script.
