### PR TITLE
Node server requires express and body-parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ There are several simple server implementations included. They all serve static 
 
 ```sh
 npm install
+npm install express
+npm install body-parser
 node server.js
 ```
 


### PR DESCRIPTION
Without these installed, the `node server.js` command will throw `Error: Cannot find module 'express'`.