### PR TITLE
Modified server.js so that Cors is allowed in NodeJS server.

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,6 +23,11 @@ app.set('port', (process.env.PORT || 3000));
 app.use('/', express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
+app.use(function(req, res, next) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    next();
+});
 
 app.get('/api/comments', function(req, res) {
   fs.readFile(COMMENTS_FILE, function(err, data) {


### PR DESCRIPTION
Currently, when users go through the ReactJS tutorial and reach the part dealing with fetching data from a server, they're not able to successfully run this code block that exists in CommentBox.jsx without running into Cors related issues:

    componentDidMount: function() {
        $.ajax({
            url: this.props.url,
            dataType: 'json',
            cache: false,
            success: function(data) {
                this.setState({data: data});
            }.bind(this),
            error: function(xhr, status, err) {
                console.error(this.props.url, status, err.toString());
            }.bind(this)
       });
  }

By accepting this change, users going through the tutorial won't face issues when trying to retrieve data from the endpoints set up in server.js.