### PR TITLE
Remove unessessary px suffix from size of zero pixels

### DIFF
--- a/public/css/base.css
+++ b/public/css/base.css
@@ -23,7 +23,7 @@ code {
   font-family: "Bitstream Vera Sans Mono", Consolas, Courier, monospace;
   font-size: 12px;
   margin: 0 2px;
-  padding: 0px 5px;
+  padding: 0 5px;
 }
 
 h1, h2, h3, h4 {


### PR DESCRIPTION
Just to be consistent.