### PR TITLE
Add delay to response in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,7 +31,9 @@ app.get('/api/comments', function(req, res) {
       process.exit(1);
     }
     res.setHeader('Cache-Control', 'no-cache');
-    res.json(JSON.parse(data));
+    setTimeout(function () {
+      res.json(JSON.parse(data));
+    }, 200);
   });
 });
 
@@ -57,7 +59,9 @@ app.post('/api/comments', function(req, res) {
         process.exit(1);
       }
       res.setHeader('Cache-Control', 'no-cache');
-      res.json(comments);
+      setTimeout(function () {
+        res.json(comments);
+      }, 200);
     });
   });
 });


### PR DESCRIPTION
Most users run the server locally, therefore AJAX requests seem instantaneous/synchronous, when they're not.

This PR puts a small delay before server response to allow user to perceive asynchronism.

Thank you.