### PR TITLE
check if id is passed as a query parameter and dont add if it is

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -23,7 +23,8 @@ server.mount_proc '/api/comments' do |req, res|
 
   if req.request_method == 'POST'
     # Assume it's well formed
-    comment = { id: (Time.now.to_f * 1000).to_i }
+    comment = {}
+    comment[:id] = (Time.now.to_f * 1000).to_i if !req.query.include?("id")
     req.query.each do |key, value|
       comment[key] = value.force_encoding('UTF-8')
     end


### PR DESCRIPTION
At the end of the tutorial a "optimistic update" option is added which passes the id to the server. In the current code the json file gets 2 id attributes in it. This check should prevent it.