### PR TITLE
CORS permissive example server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.4.3",
-    "express": "^4.4.5"
+    "express": "^4.4.5",
+    "permissive-cors": "^1.0.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "body-parser": "^1.4.3",
     "express": "^4.4.5",
-    "permissive-cors": "^1.0.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ var path = require('path');
 var express = require('express');
 var bodyParser = require('body-parser');
 var app = express();
+var cors = require('permissive-cors');
 
 var COMMENTS_FILE = path.join(__dirname, 'comments.json');
 
@@ -23,6 +24,7 @@ app.set('port', (process.env.PORT || 3000));
 app.use('/', express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
+app.use(cors());
 
 app.get('/api/comments', function(req, res) {
   fs.readFile(COMMENTS_FILE, function(err, data) {

--- a/server.js
+++ b/server.js
@@ -15,7 +15,6 @@ var path = require('path');
 var express = require('express');
 var bodyParser = require('body-parser');
 var app = express();
-var cors = require('permissive-cors');
 
 var COMMENTS_FILE = path.join(__dirname, 'comments.json');
 
@@ -24,7 +23,18 @@ app.set('port', (process.env.PORT || 3000));
 app.use('/', express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
-app.use(cors());
+app.use(function(req, res, next) {
+    //set permissive CORS headers
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,HEAD,PUT,POST,DELETE,PATCH');
+    res.setHeader('Access-Control-Allow-Headers', req.headers['access-control-request-headers'] || "");
+
+    if (req.method == 'OPTIONS') //respond to preflights with 200
+        return res.end('', 200);
+
+    next();
+});
+
 
 app.get('/api/comments', function(req, res) {
   fs.readFile(COMMENTS_FILE, function(err, data) {


### PR DESCRIPTION
When following this tutorial, specifics about the different ways to set up ports/webpack/file serving/etc should tend towards "just working" and allow people to not get derailed. This PR sets the node.js example server to use lightweight middle-ware which sets HTTP headers to allow cross-origin requests. 
Anecdotally, I lost a chunk of time debugging this problem when I was running the comment api server on ::3000, and webpack-dev-server on ::8080. Could be worth setting the other servers to do the same.
Thanks for this resource! 