### PR TITLE
Add CORS headers to other servers

### DIFF
--- a/server.go
+++ b/server.go
@@ -84,11 +84,13 @@ func handleComments(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		io.Copy(w, bytes.NewReader(commentData))
 
 	case "GET":
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		// stream the contents of the file to the response
 		io.Copy(w, bytes.NewReader(commentData))
 

--- a/server.php
+++ b/server.php
@@ -45,6 +45,7 @@ function routeRequest()
         }
         header('Content-Type: application/json');
         header('Cache-Control: no-cache');
+        header('Access-Control-Allow-Origin: *');
         echo $comments;
     } else {
         return false;

--- a/server.pl
+++ b/server.pl
@@ -19,6 +19,8 @@ any '/' => sub { $_[0]->reply->static('index.html') };
 any [qw(GET POST)] => '/api/comments' => sub {
   my $self = shift;
   my $comments = decode_json (do { local(@ARGV,$/) = 'comments.json';<> });
+  $self->res->headers->cache_control('no-cache');
+  $self->res->headers->access_control_allow_origin('*');
 
   if ($self->req->method eq 'POST')
   {

--- a/server.py
+++ b/server.py
@@ -30,7 +30,7 @@ def comments_handler():
         with open('comments.json', 'w') as file:
             file.write(json.dumps(comments, indent=4, separators=(',', ': ')))
 
-    return Response(json.dumps(comments), mimetype='application/json', headers={'Cache-Control': 'no-cache'})
+    return Response(json.dumps(comments), mimetype='application/json', headers={'Cache-Control': 'no-cache', 'Access-Control-Allow-Origin': '*'})
 
 if __name__ == '__main__':
     app.run(port=int(os.environ.get("PORT",3000)))

--- a/server.rb
+++ b/server.rb
@@ -40,6 +40,7 @@ server.mount_proc '/api/comments' do |req, res|
   # always return json
   res['Content-Type'] = 'application/json'
   res['Cache-Control'] = 'no-cache'
+  res['Access-Control-Allow-Origin'] = '*'
   res.body = JSON.generate(comments)
 end
 


### PR DESCRIPTION
#120 added them for the JS server. This adds it to the rest. And adds the Cache-Control header to the Perl impl too, which was missing all of the explicit headers we want.