### PR TITLE
remove unexpected trailing comma to resolve lint error

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ app.post('/api/comments', function(req, res) {
     var newComment = {
       id: Date.now(),
       author: req.body.author,
-      text: req.body.text,
+      text: req.body.text
     };
     comments.push(newComment);
     fs.writeFile(COMMENTS_FILE, JSON.stringify(comments, null, 4), function(err) {


### PR DESCRIPTION
Remove an unexpected trailing comma in server.js to resolve a lint error.