### PR TITLE
Set debug=True flag for Flask server

### DIFF
--- a/server.py
+++ b/server.py
@@ -41,4 +41,4 @@ def comments_handler():
 
 
 if __name__ == '__main__':
-    app.run(port=int(os.environ.get("PORT", 3000)))
+    app.run(port=int(os.environ.get("PORT", 3000)), debug=True)


### PR DESCRIPTION
From the Flask docs, setting `debug=True`:

1. activates the debugger
2. activates the automatic reloader
3. enables the debug mode on the Flask application

The automatic reloader is not so important for the purposes of the tutorial, but if users modify the Flask server in anyway and introduce a syntax error for example, debug mode dumps out exceptions to the console instead of swallowing them.

I was working along with the tutorial last night and simply did a copypasta of `server.py` instead of cloning the repo which resulted in me missing `comments.py`. When querying the comments endpoint, I got a 500 error, but no useful output in the console:

```
127.0.0.1 - - [27/Aug/2016 09:05:18] "GET /api/comments HTTP/1.1" 500 -
```

Meanwhile, if debug mode is enabled, I get a handy Traceback dumped to stdout:

```
Traceback (most recent call last):
  File "/path/to/pyenvs/.pyenv/versions/react/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/path/to/pyenvs/.pyenv/versions/react/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/path/to/pyenvs/.pyenv/versions/react/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/path/to/pyenvs/.pyenv/versions/react/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/path/to/pyenvs/.pyenv/versions/react/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/path/to/pyenvs/.pyenv/versions/react/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/path/to/pyenvs/.pyenv/versions/react/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/path/to/pyenvs/.pyenv/versions/react/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/path/to/pyenvs/code/learn/react/server.py", line 22, in comments_handler
    with open('comments.json', 'r') as f:
IOError: [Errno 2] No such file or directory: 'comments.json'
```

Although my specific example is a bit contrived as I doubt many other users copy and paste `server.py`, debug mode is still handy for local development settings.