### PR TITLE
feat(babel): Bump up the babel version 5.x to 6.x

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/base.css" />
     <script src="https://unpkg.com/react@15.3.0/dist/react.js"></script>
     <script src="https://unpkg.com/react-dom@15.3.0/dist/react-dom.js"></script>
-    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
     <script src="https://unpkg.com/jquery@3.1.0/dist/jquery.min.js"></script>
     <script src="https://unpkg.com/remarkable@1.6.2/dist/remarkable.min.js"></script>
   </head>


### PR DESCRIPTION
Hello,
Is there any reasons to keep `babel-core` version as 5.x?
If not, why don't we upgrade babel's version as 6.x?
Current version is too old for tutorial I think.

Thanks!

## Code Differences Explanation
As you know `babel-browser` is [deprecated](https://babeljs.io/docs/usage/browser/). According to https://github.com/babel/babel.github.io/commit/3dbf5ce194d3768059b1aa7b2968b8835d9ee940, babel's [Try it Out link](http://babeljs.io/repl) uses [`babel-standalone`](https://github.com/Daniel15/babel-standalone). So I think it is great alternatives.